### PR TITLE
Add option to override spider configuration when starting a run

### DIFF
--- a/src/Core/RunFactory.php
+++ b/src/Core/RunFactory.php
@@ -18,6 +18,7 @@ use RoachPHP\Downloader\DownloaderMiddlewareInterface;
 use RoachPHP\Downloader\Middleware\DownloaderMiddlewareAdapter;
 use RoachPHP\Extensions\ExtensionInterface;
 use RoachPHP\ItemPipeline\Processors\ItemProcessorInterface;
+use RoachPHP\Spider\Configuration\Overrides;
 use RoachPHP\Spider\Middleware\SpiderMiddlewareAdapter;
 use RoachPHP\Spider\SpiderInterface;
 use RoachPHP\Spider\SpiderMiddlewareInterface;
@@ -28,9 +29,14 @@ final class RunFactory
     {
     }
 
-    public function fromSpider(SpiderInterface $spider): Run
+    public function fromSpider(SpiderInterface $spider, ?Overrides $overrides = null): Run
     {
         $configuration = $spider->loadConfiguration();
+
+        if (null !== $overrides) {
+            $configuration = $configuration->withOverrides($overrides);
+            $spider->withConfiguration($configuration);
+        }
 
         return new Run(
             $spider->getInitialRequests(),

--- a/src/Roach.php
+++ b/src/Roach.php
@@ -29,6 +29,7 @@ use RoachPHP\Scheduling\ArrayRequestScheduler;
 use RoachPHP\Scheduling\RequestSchedulerInterface;
 use RoachPHP\Scheduling\Timing\ClockInterface;
 use RoachPHP\Scheduling\Timing\SystemClock;
+use RoachPHP\Spider\Configuration\Overrides;
 use RoachPHP\Spider\SpiderInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -45,7 +46,7 @@ final class Roach
     /**
      * @psalm-param class-string<SpiderInterface> $spiderClass
      */
-    public static function startSpider(string $spiderClass): void
+    public static function startSpider(string $spiderClass, ?Overrides $overrides = null): void
     {
         self::$container ??= self::defaultContainer();
 
@@ -53,7 +54,7 @@ final class Roach
         $runFactory = new RunFactory(self::$container);
 
         $engine = self::resolve(Engine::class);
-        $run = $runFactory->fromSpider($spider);
+        $run = $runFactory->fromSpider($spider, $overrides);
 
         $engine->start($run);
     }

--- a/src/Spider/AbstractSpider.php
+++ b/src/Spider/AbstractSpider.php
@@ -40,6 +40,11 @@ abstract class AbstractSpider implements SpiderInterface
         return $this->initialRequests();
     }
 
+    final public function withConfiguration(Configuration $configuration): void
+    {
+        $this->configuration = $configuration;
+    }
+
     final public function loadConfiguration(): Configuration
     {
         return $this->configuration;
@@ -49,7 +54,7 @@ abstract class AbstractSpider implements SpiderInterface
         string $method,
         string $url,
         string $parseMethod = 'parse',
-        array $options = []
+        array $options = [],
     ): ParseResult {
         return ParseResult::request($method, $url, [$this, $parseMethod], $options);
     }

--- a/src/Spider/Configuration/Configuration.php
+++ b/src/Spider/Configuration/Configuration.php
@@ -21,7 +21,7 @@ use RoachPHP\Spider\SpiderMiddlewareInterface;
 final class Configuration
 {
     /**
-     * @param string[]                                      $startUrls
+     * @param string[] $startUrls
      * @param class-string<DownloaderMiddlewareInterface>[] $downloaderMiddleware
      * @param class-string<ItemProcessorInterface>[]        $itemProcessors
      * @param class-string<SpiderMiddlewareInterface>[]     $spiderMiddleware
@@ -36,5 +36,20 @@ final class Configuration
         public int $concurrency,
         public int $requestDelay,
     ) {
+    }
+
+    public function withOverrides(Overrides $overrides): self
+    {
+        $newValues = \array_merge([
+            'startUrls' => $this->startUrls,
+            'downloaderMiddleware' => $this->downloaderMiddleware,
+            'spiderMiddleware' => $this->spiderMiddleware,
+            'extensions' => $this->extensions,
+            'itemProcessors' => $this->itemProcessors,
+            'concurrency' => $this->concurrency,
+            'requestDelay' => $this->requestDelay,
+        ], $overrides->toArray());
+
+        return new self(...$newValues);
     }
 }

--- a/src/Spider/Configuration/Overrides.php
+++ b/src/Spider/Configuration/Overrides.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/roach-php/roach
+ */
+
+namespace RoachPHP\Spider\Configuration;
+
+use RoachPHP\Downloader\DownloaderMiddlewareInterface;
+use RoachPHP\Extensions\ExtensionInterface;
+use RoachPHP\ItemPipeline\Processors\ItemProcessorInterface;
+use RoachPHP\Spider\SpiderMiddlewareInterface;
+
+/**
+ * @psalm-immutable
+ */
+final class Overrides
+{
+    /**
+     * @param null|string[] $startUrls
+     * @param class-string<DownloaderMiddlewareInterface>[]|null $downloaderMiddleware
+     * @param class-string<SpiderMiddlewareInterface>[]|null $spiderMiddleware
+     * @param class-string<ItemProcessorInterface>[]|null $itemProcessors
+     * @param class-string<ExtensionInterface>[]|null $extensions
+     */
+    public function __construct(
+        public ?array $startUrls = null,
+        public ?array $downloaderMiddleware = null,
+        public ?array $spiderMiddleware = null,
+        public ?array $itemProcessors = null,
+        public ?array $extensions = null,
+        public ?int $concurrency = null,
+        public ?int $requestDelay = null,
+    ) {
+    }
+
+    /**
+     * @psalm-suppress MoreSpecificReturnType, LessSpecificReturnStatement
+     *
+     * @return array{
+     *     startUrls?: string[],
+     *     downloaderMiddleware?: class-string<DownloaderMiddlewareInterface>[],
+     *     spiderMiddleware?: class-string<SpiderMiddlewareInterface>[],
+     *     itemProcessors?: class-string<ItemProcessorInterface>[],
+     *     extensions?: class-string<ExtensionInterface>[],
+     *     concurrency?: int,
+     *     requestDelay?: int,
+     * }
+     */
+    public function toArray(): array
+    {
+        return \array_filter([
+            'startUrls' => $this->startUrls,
+            'downloaderMiddleware' => $this->downloaderMiddleware,
+            'spiderMiddleware' => $this->spiderMiddleware,
+            'itemProcessors' => $this->itemProcessors,
+            'extensions' => $this->extensions,
+            'concurrency' => $this->concurrency,
+            'requestDelay' => $this->requestDelay,
+        ], static fn ($value) => null !== $value);
+    }
+}

--- a/src/Spider/SpiderInterface.php
+++ b/src/Spider/SpiderInterface.php
@@ -21,6 +21,13 @@ interface SpiderInterface
     public function loadConfiguration(): Configuration;
 
     /**
+     * Provides an override configuration the spider is supposed to
+     * use instead of its own configuration. This should modify the
+     * existing instance.
+     */
+    public function withConfiguration(Configuration $configuration): void;
+
+    /**
      * @return Request[]
      */
     public function getInitialRequests(): array;

--- a/tests/Spider/Configuration/ConfigurationTest.php
+++ b/tests/Spider/Configuration/ConfigurationTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/roach-php/roach
+ */
+
+namespace RoachPHP\Tests\Spider\Configuration;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use RoachPHP\Spider\Configuration\Configuration;
+use RoachPHP\Spider\Configuration\Overrides;
+use RoachPHP\Tests\Fixtures\Extension;
+use RoachPHP\Tests\Fixtures\ItemProcessor;
+use RoachPHP\Tests\Fixtures\RequestDownloaderMiddleware;
+use RoachPHP\Tests\Fixtures\RequestSpiderMiddleware;
+use RoachPHP\Tests\Fixtures\ResponseDownloaderMiddleware;
+use RoachPHP\Tests\Fixtures\ResponseSpiderMiddleware;
+
+/**
+ * @internal
+ */
+final class ConfigurationTest extends TestCase
+{
+    /**
+     * @dataProvider overridesProvider
+     */
+    public function testMergeWithOverrides(array $overrides, callable $verifyConfig): void
+    {
+        $originalConfig = $this->makeConfiguration([
+            'startUrls' => ['::original-url::'],
+            'spiderMiddleware' => [
+                RequestSpiderMiddleware::class,
+            ],
+            'downloaderMiddleware' => [
+                RequestDownloaderMiddleware::class,
+            ],
+            'itemProcessors' => [
+                ItemProcessor::class,
+            ],
+            'extensions' => [
+                Extension::class,
+            ],
+            'requestDelay' => 1,
+            'concurrency' => 1,
+        ]);
+
+        $overrideConfig = $originalConfig->withOverrides(new Overrides(...$overrides));
+
+        $verifyConfig($overrideConfig);
+    }
+
+    public function overridesProvider(): Generator
+    {
+        yield from [
+            'override startUrls' => [
+                ['startUrls' => ['::override-url::']],
+                static function (Configuration $config): void {
+                    self::assertEquals(['::override-url::'], $config->startUrls);
+                },
+            ],
+
+            'override spiderMiddleware' => [
+                ['spiderMiddleware' => [ResponseSpiderMiddleware::class]],
+                static function (Configuration $config): void {
+                    self::assertEquals([ResponseSpiderMiddleware::class], $config->spiderMiddleware);
+                },
+            ],
+
+            'override downloaderMiddleware' => [
+                ['downloaderMiddleware' => [ResponseDownloaderMiddleware::class]],
+                static function (Configuration $config): void {
+                    self::assertEquals([ResponseDownloaderMiddleware::class], $config->downloaderMiddleware);
+                },
+            ],
+
+            'override itemProcessors' => [
+                ['itemProcessors' => []],
+                static function (Configuration $config): void {
+                    self::assertEmpty($config->itemProcessors);
+                },
+            ],
+
+            'override extensions' => [
+                ['extensions' => []],
+                static function (Configuration $config): void {
+                    self::assertEmpty($config->extensions);
+                },
+            ],
+
+            'override concurrency' => [
+                ['concurrency' => 10],
+                static function (Configuration $config): void {
+                    self::assertSame(10, $config->concurrency);
+                },
+            ],
+
+            'override requestDelay' => [
+                ['requestDelay' => 11],
+                static function (Configuration $config): void {
+                    self::assertSame(11, $config->requestDelay);
+                },
+            ],
+        ];
+    }
+
+    private function makeConfiguration(array $values): Configuration
+    {
+        $defaults = [
+            'startUrls' => [],
+            'spiderMiddleware' => [],
+            'downloaderMiddleware' => [],
+            'itemProcessors' => [],
+            'extensions' => [],
+            'concurrency' => 1,
+            'requestDelay' => 1,
+        ];
+
+        return new Configuration(...\array_merge($defaults, $values));
+    }
+}


### PR DESCRIPTION
This PR adds the option of overriding some or all of a spider’s configuration at runtime.

To so, we can now pass an option `$overrides` parameter to the `Roach::startSpider` function. This parameter takes an instance of `RoachPHP\Spider\Configuration\Overrides` which will get merged with the spider’s own configuration.

```php
Roach::startSpider(
    MySpider::class, 
    new Overrides(startUrls: ['https://roach-php.dev/docs/installation'])
);
```

## Rationale

While having all configuration defined inside the spider class itself is certainly convenient, we’re essentially hard coding everything about a spider. For example, before this PR, it would not have been possible to dynamically pass different start URLs to spider. With this PR, we could now accept the start URL through the UI, load it from the database or conjure it up some other way. We can then start a run of a spider using that URL.

```php
class SpiderController
{
    public function __invoke(Request $request)
    {
        // Request validation is left as an exercise for the reader.
        $startUrl = $request->get('start_url');

        // Or dispatch a job here to start the run or whatever.
        Roach::startSpider(
            MySpider::class, 
            new Overrides(['startUrls' => [$startUrl])
        );

        return redirect()->back();
    }
}
```

_Note that his example assumes that the parsing logic you have written works for all of these dynamic URLs. Validating the start urls is still up to you_.

The same holds true for all the other spider configuration values as well. Maybe we want to quickly fire off a test run against a specific URL without having to change the actual spider class itself. We could override the `concurrency` and `requestDelay` parameters accordingly as to not hammer the server with requests. We could also register the `MaxRequestExtension` for this run to ensure that we stop the run after the first request.

```php
Roach::startSpider(
    MySpider::class,
    new Overrides([
        'extensions' => [
            LoggerExtensions::class,
            [MaxRequestExtension::class, ['limit' => 1]],
        ]
    ])
);
```

Note that when overriding values, they will _replace_ the spider’s configuration, not get merged with it. In the example above we have to make sure to also register the `LoggerExtension` for the run even if the spider’s own configuration already registers it.