### PR TITLE
Add Configurable::withOptions method

### DIFF
--- a/src/Support/Configurable.php
+++ b/src/Support/Configurable.php
@@ -21,6 +21,11 @@ trait Configurable
 
     private array $resolvedOptions = [];
 
+    public static function withOptions(array $options): array
+    {
+        return [static::class, $options];
+    }
+
     final public function configure(array $options): void
     {
         if ($this->optionsResolved) {


### PR DESCRIPTION
This adds a `withOptions` to the `Configurable` trait so that you can create `[$classname, $options]` tuples more fluently.

Eg.:

```diff
class MySpider extends BasicSpider
{
    public array $itemProcessors = [
        // We care only about games with a minimum of
        // 10 scored goals. Wow!
-       [
-           MinimumScoredGoalsProcessor::class,
-           ['threshold' => 10],
-       ],
+       MinimumScoredGoalsProcessor::withOptions(['threshold' => 10]),
    ];
}
```