### PR TITLE
Make InteractsWithRequestsAndResponses available for testing

### DIFF
--- a/src/Testing/Concerns/InteractsWithRequestsAndResponses.php
+++ b/src/Testing/Concerns/InteractsWithRequestsAndResponses.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/roach-php/roach
  */
 
-namespace RoachPHP\Tests;
+namespace RoachPHP\Testing\Concerns;
 
 use Closure;
 use Generator;

--- a/tests/Downloader/DownloaderMiddlewareAdapterTest.php
+++ b/tests/Downloader/DownloaderMiddlewareAdapterTest.php
@@ -22,7 +22,7 @@ use RoachPHP\Downloader\Middleware\ResponseMiddlewareInterface;
 use RoachPHP\Http\Request;
 use RoachPHP\Http\Response;
 use RoachPHP\Support\Configurable;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 
 /**
  * @internal

--- a/tests/Downloader/DownloaderTest.php
+++ b/tests/Downloader/DownloaderTest.php
@@ -22,7 +22,7 @@ use RoachPHP\Events\RequestSending;
 use RoachPHP\Http\FakeClient;
 use RoachPHP\Http\Request;
 use RoachPHP\Http\Response;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 
 /**
  * @internal

--- a/tests/Downloader/Middleware/CookieMiddlewareTest.php
+++ b/tests/Downloader/Middleware/CookieMiddlewareTest.php
@@ -16,7 +16,7 @@ namespace RoachPHP\Tests\Downloader\Middleware;
 use GuzzleHttp\Cookie\CookieJar;
 use PHPUnit\Framework\TestCase;
 use RoachPHP\Downloader\Middleware\CookieMiddleware;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 
 /**
  * @internal

--- a/tests/Downloader/Middleware/ExecuteJavascriptMiddlewareTest.php
+++ b/tests/Downloader/Middleware/ExecuteJavascriptMiddlewareTest.php
@@ -15,9 +15,9 @@ namespace RoachPHP\Tests\Downloader\Middleware;
 
 use Exception;
 use RoachPHP\Downloader\Middleware\ExecuteJavascriptMiddleware;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 use RoachPHP\Testing\FakeLogger;
 use RoachPHP\Tests\IntegrationTest;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
 use Spatie\Browsershot\Browsershot;
 
 /**

--- a/tests/Downloader/Middleware/FakeMiddlewareTest.php
+++ b/tests/Downloader/Middleware/FakeMiddlewareTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 use RoachPHP\Downloader\Middleware\FakeMiddleware;
 use RoachPHP\Http\Request;
 use RoachPHP\Http\Response;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 
 /**
  * @internal

--- a/tests/Downloader/Middleware/RequestDeduplicationMiddlewareTest.php
+++ b/tests/Downloader/Middleware/RequestDeduplicationMiddlewareTest.php
@@ -15,8 +15,8 @@ namespace RoachPHP\Tests\Downloader\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use RoachPHP\Downloader\Middleware\RequestDeduplicationMiddleware;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 use RoachPHP\Testing\FakeLogger;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
 
 /**
  * @group downloader

--- a/tests/Downloader/Middleware/RobotsTxtMiddlewareTest.php
+++ b/tests/Downloader/Middleware/RobotsTxtMiddlewareTest.php
@@ -27,8 +27,8 @@ use RoachPHP\Scheduling\ArrayRequestScheduler;
 use RoachPHP\Scheduling\Timing\FakeClock;
 use RoachPHP\Spider\ParseResult;
 use RoachPHP\Spider\Processor;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 use RoachPHP\Tests\IntegrationTest;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
 
 /**
  * @internal

--- a/tests/Downloader/Middleware/UserAgentMiddlewareTest.php
+++ b/tests/Downloader/Middleware/UserAgentMiddlewareTest.php
@@ -15,7 +15,7 @@ namespace RoachPHP\Tests\Downloader\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use RoachPHP\Downloader\Middleware\UserAgentMiddleware;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 
 /**
  * @group downloader

--- a/tests/EngineTest.php
+++ b/tests/EngineTest.php
@@ -27,6 +27,7 @@ use RoachPHP\Scheduling\ArrayRequestScheduler;
 use RoachPHP\Scheduling\Timing\FakeClock;
 use RoachPHP\Spider\ParseResult;
 use RoachPHP\Spider\Processor;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 use RoachPHP\Testing\FakeLogger;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 

--- a/tests/Extensions/LoggerExtensionTest.php
+++ b/tests/Extensions/LoggerExtensionTest.php
@@ -23,8 +23,8 @@ use RoachPHP\Events\RunStarting;
 use RoachPHP\Extensions\ExtensionInterface;
 use RoachPHP\Extensions\LoggerExtension;
 use RoachPHP\ItemPipeline\Item;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 use RoachPHP\Testing\FakeLogger;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
 
 /**
  * @internal

--- a/tests/Extensions/MaxRequestExtensionTest.php
+++ b/tests/Extensions/MaxRequestExtensionTest.php
@@ -18,7 +18,7 @@ use RoachPHP\Events\RequestScheduling;
 use RoachPHP\Events\RequestSending;
 use RoachPHP\Extensions\ExtensionInterface;
 use RoachPHP\Extensions\MaxRequestExtension;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 
 /**
  * @internal

--- a/tests/Extensions/StatsCollectorExtensionTest.php
+++ b/tests/Extensions/StatsCollectorExtensionTest.php
@@ -25,8 +25,8 @@ use RoachPHP\Extensions\ExtensionInterface;
 use RoachPHP\Extensions\StatsCollectorExtension;
 use RoachPHP\ItemPipeline\Item;
 use RoachPHP\Scheduling\Timing\FakeClock;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 use RoachPHP\Testing\FakeLogger;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\RequestInterface;
 use RoachPHP\Http\Client;
 use RoachPHP\Http\RequestException;
 use RoachPHP\Http\Response;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 
 final class ClientTest extends TestCase
 {

--- a/tests/Http/FakeClientTest.php
+++ b/tests/Http/FakeClientTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 use RoachPHP\Http\FakeClient;
 use RoachPHP\Http\Response;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 
 /**
  * @internal

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 use RoachPHP\Http\Response;
 use RoachPHP\Spider\ParseResult;
 use RoachPHP\Support\DroppableInterface;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 use RoachPHP\Tests\Support\DroppableTest;
 
 /**

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -18,7 +18,7 @@ use GuzzleHttp\Psr7\Stream;
 use PHPUnit\Framework\TestCase;
 use RoachPHP\Http\Response;
 use RoachPHP\Support\DroppableInterface;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 use RoachPHP\Tests\Support\DroppableTest;
 
 /**

--- a/tests/Scheduling/ArrayRequestSchedulerTest.php
+++ b/tests/Scheduling/ArrayRequestSchedulerTest.php
@@ -17,7 +17,7 @@ use Generator;
 use PHPUnit\Framework\TestCase;
 use RoachPHP\Scheduling\ArrayRequestScheduler;
 use RoachPHP\Scheduling\Timing\FakeClock;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 
 /**
  * @group queue

--- a/tests/Spider/Middleware/FakeHandlerTest.php
+++ b/tests/Spider/Middleware/FakeHandlerTest.php
@@ -19,7 +19,7 @@ use RoachPHP\Http\Response;
 use RoachPHP\ItemPipeline\Item;
 use RoachPHP\ItemPipeline\ItemInterface;
 use RoachPHP\Spider\Middleware\FakeHandler;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 
 /**
  * @internal

--- a/tests/Spider/Middleware/MaximumCrawlDepthMiddlewareTest.php
+++ b/tests/Spider/Middleware/MaximumCrawlDepthMiddlewareTest.php
@@ -16,7 +16,7 @@ namespace RoachPHP\Tests\Spider\Middleware;
 use Generator;
 use PHPUnit\Framework\TestCase;
 use RoachPHP\Spider\Middleware\MaximumCrawlDepthMiddleware;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 
 /**
  * @internal

--- a/tests/Spider/Middleware/SpiderMiddlewareAdapterTest.php
+++ b/tests/Spider/Middleware/SpiderMiddlewareAdapterTest.php
@@ -25,7 +25,7 @@ use RoachPHP\Spider\Middleware\ResponseMiddlewareInterface;
 use RoachPHP\Spider\Middleware\SpiderMiddlewareAdapter;
 use RoachPHP\Spider\SpiderMiddlewareInterface;
 use RoachPHP\Support\Configurable;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 
 /**
  * @internal

--- a/tests/Spider/ProcessorTest.php
+++ b/tests/Spider/ProcessorTest.php
@@ -24,7 +24,7 @@ use RoachPHP\ItemPipeline\Item;
 use RoachPHP\Spider\Middleware\FakeHandler;
 use RoachPHP\Spider\ParseResult;
 use RoachPHP\Spider\Processor;
-use RoachPHP\Tests\InteractsWithRequestsAndResponses;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
 
 /**
  * @internal


### PR DESCRIPTION
The `RoachPHP\Tests\InteractsWithRequestsAndResponses` trait is great for testing middleware and such.

However, because of its current namespace, it's unavailable because the dev namespace is not autoloaded by default.

Moving this trait to the `src` directory allows us to use this trait in our own tests as well. 

[Laravel](https://github.com/laravel/framework/tree/9.x/src/Illuminate/Foundation/Testing/Concerns) and [Livewire](https://github.com/livewire/livewire/tree/master/src/Testing/Concerns) also namespace their testing traits in this way.

If this PR is accepted, I can also submit a small PR to include this trait in the docs.