### PR TITLE
Fix to align with symfony/console 6.1

### DIFF
--- a/src/Shell/Commands/FetchCommand.php
+++ b/src/Shell/Commands/FetchCommand.php
@@ -18,10 +18,12 @@ use Psy\Command\Command;
 use Psy\Shell;
 use RoachPHP\Http\Request;
 use RoachPHP\Http\Response;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'fetch')]
 final class FetchCommand extends Command
 {
     protected static $defaultName = 'fetch';

--- a/src/Shell/Commands/RunSpiderCommand.php
+++ b/src/Shell/Commands/RunSpiderCommand.php
@@ -16,11 +16,13 @@ namespace RoachPHP\Shell\Commands;
 use RoachPHP\Roach;
 use RoachPHP\Shell\InvalidSpiderException;
 use RoachPHP\Shell\Resolver\NamespaceResolverInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'roach:run')]
 final class RunSpiderCommand extends Command
 {
     protected static $defaultName = 'roach:run';

--- a/src/Shell/Repl.php
+++ b/src/Shell/Repl.php
@@ -17,6 +17,7 @@ use Psy\Configuration;
 use Psy\Shell;
 use RoachPHP\Http\Response;
 use RoachPHP\Shell\Commands\FetchCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
@@ -25,6 +26,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Link;
 
+#[AsCommand(name: 'roach:shell')]
 final class Repl extends Command
 {
     protected static $defaultName = 'roach:shell';


### PR DESCRIPTION
Hi Kai,

I got the warning below
`local.WARNING: Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute to the "RoachPHP\Shell\Commands\RunSpiderCommand" class instead.`

When trying out Roach. The fix is pretty straight forward I guess, but then again, I'm not an expert in these "advanced syntax" stuff