### PR TITLE
Custom item classes

### DIFF
--- a/.github/workflows/fix-style.yml
+++ b/.github/workflows/fix-style.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.1
 
       - name: Install dependencies
         run: composer install

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "guzzlehttp/guzzle": "^7.3",
+        "guzzlehttp/guzzle": "^7.4.5",
         "jakeasmith/http_build_url": "^1.0.1",
         "league/container": "^4.2",
         "monolog/monolog": "^2.3",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "slim/slim": "^4.8",
         "spatie/browsershot": "^3.52",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.22"
+        "vimeo/psalm": "^4.23"
     },
     "suggest": {
         "spatie/browsershot": "Required to execute Javascript in spiders"

--- a/composer.lock
+++ b/composer.lock
@@ -4,26 +4,26 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "69f565bef8fcb563ee7fc4fb4ba4ea6b",
+    "content-hash": "ab37cd7cd4874bf2445f157f34e08c03",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.4.2",
+            "version": "7.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "ac1ec1cd9b5624694c3a40be801d94137afb12b4"
+                "reference": "1dd98b0564cb3f6bd16ce683cb755f94c10fbd82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ac1ec1cd9b5624694c3a40be801d94137afb12b4",
-                "reference": "ac1ec1cd9b5624694c3a40be801d94137afb12b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/1dd98b0564cb3f6bd16ce683cb755f94c10fbd82",
+                "reference": "1dd98b0564cb3f6bd16ce683cb755f94c10fbd82",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^1.5",
-                "guzzlehttp/psr7": "^1.8.3 || ^2.1",
+                "guzzlehttp/psr7": "^1.9 || ^2.4",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.2 || ^3.0"
@@ -112,7 +112,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.4.2"
+                "source": "https://github.com/guzzle/guzzle/tree/7.4.5"
             },
             "funding": [
                 {
@@ -128,7 +128,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-20T14:16:28+00:00"
+            "time": "2022-06-20T22:16:13+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -216,16 +216,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.2.1",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "c94a94f120803a18554c1805ef2e539f8285f9a2"
+                "reference": "13388f00956b1503577598873fffb5ae994b5737"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/c94a94f120803a18554c1805ef2e539f8285f9a2",
-                "reference": "c94a94f120803a18554c1805ef2e539f8285f9a2",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/13388f00956b1503577598873fffb5ae994b5737",
+                "reference": "13388f00956b1503577598873fffb5ae994b5737",
                 "shasum": ""
             },
             "require": {
@@ -249,7 +249,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-master": "2.4-dev"
                 }
             },
             "autoload": {
@@ -311,7 +311,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.2.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.4.0"
             },
             "funding": [
                 {
@@ -327,7 +327,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-20T21:55:58+00:00"
+            "time": "2022-06-20T21:43:11+00:00"
         },
         {
             "name": "jakeasmith/http_build_url",
@@ -1314,25 +1314,25 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.0.1",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
+                "reference": "07f1b9cc2ffee6aaafcf4b710fbc38ff736bd918"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/07f1b9cc2ffee6aaafcf4b710fbc38ff736bd918",
+                "reference": "07f1b9cc2ffee6aaafcf4b710fbc38ff736bd918",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.1-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -1361,7 +1361,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.1.0"
             },
             "funding": [
                 {
@@ -1377,7 +1377,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2022-02-25T11:15:52+00:00"
         },
         {
             "name": "symfony/dom-crawler",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "74e5ff97999960f5688cdb4c35a862a3",
+    "content-hash": "69f565bef8fcb563ee7fc4fb4ba4ea6b",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -8018,16 +8018,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.22.0",
+            "version": "4.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "fc2c6ab4d5fa5d644d8617089f012f3bb84b8703"
+                "reference": "f1fe6ff483bf325c803df9f510d09a03fd796f88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/fc2c6ab4d5fa5d644d8617089f012f3bb84b8703",
-                "reference": "fc2c6ab4d5fa5d644d8617089f012f3bb84b8703",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f1fe6ff483bf325c803df9f510d09a03fd796f88",
+                "reference": "f1fe6ff483bf325c803df9f510d09a03fd796f88",
                 "shasum": ""
             },
             "require": {
@@ -8052,6 +8052,7 @@
                 "php": "^7.1|^8",
                 "sebastian/diff": "^3.0 || ^4.0",
                 "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0 || ^6.0",
+                "symfony/polyfill-php80": "^1.25",
                 "webmozart/path-util": "^2.3"
             },
             "provide": {
@@ -8118,9 +8119,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.22.0"
+                "source": "https://github.com/vimeo/psalm/tree/4.23.0"
             },
-            "time": "2022-02-24T20:34:05+00:00"
+            "time": "2022-04-28T17:35:49+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/Downloader/Downloader.php
+++ b/src/Downloader/Downloader.php
@@ -67,6 +67,7 @@ final class Downloader
 
         /**
          * @psalm-suppress UnnecessaryVarAnnotation
+         *
          * @var RequestSending $event
          */
         $event = $this->eventDispatcher->dispatch(

--- a/src/Downloader/Downloader.php
+++ b/src/Downloader/Downloader.php
@@ -65,7 +65,10 @@ final class Downloader
             }
         }
 
-        /** @var RequestSending $event */
+        /**
+         * @psalm-suppress UnnecessaryVarAnnotation
+         * @var RequestSending $event
+         */
         $event = $this->eventDispatcher->dispatch(
             new RequestSending($request),
             RequestSending::NAME,

--- a/src/ItemPipeline/AbstractItem.php
+++ b/src/ItemPipeline/AbstractItem.php
@@ -101,12 +101,21 @@ abstract class AbstractItem implements ItemInterface
 
     final public function offsetGet(mixed $offset): mixed
     {
+        /** @psalm-suppress DocblockTypeContradiction */
+        if (!\is_string($offset)) {
+            throw new InvalidArgumentException('Offset needs to be a string');
+        }
+
         /** @psalm-suppress MixedReturnStatement */
         return $this->get($offset);
     }
 
     final public function offsetSet(mixed $offset, mixed $value): void
     {
+        if (!\is_string($offset)) {
+            throw new InvalidArgumentException('Offset needs to be a string');
+        }
+
         $this->set($offset, $value);
     }
 

--- a/src/ItemPipeline/AbstractItem.php
+++ b/src/ItemPipeline/AbstractItem.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2022 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/roach-php/roach
+ */
+
+namespace RoachPHP\ItemPipeline;
+
+use InvalidArgumentException;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionProperty;
+use RoachPHP\Support\Droppable;
+use RuntimeException;
+
+abstract class AbstractItem implements ItemInterface
+{
+    use Droppable;
+
+    final public function all(): array
+    {
+        $reflectionClass = new ReflectionClass($this);
+        $properties = $reflectionClass->getProperties(ReflectionProperty::IS_PUBLIC);
+
+        return \array_reduce(
+            $properties,
+            function (array $data, ReflectionProperty $property): array {
+                /** @psalm-suppress MixedAssignment */
+                $data[$property->getName()] = $property->getValue($this);
+
+                return $data;
+            },
+            [],
+        );
+    }
+
+    final public function get(string $key, mixed $default = null): mixed
+    {
+        $reflectionClass = new ReflectionClass($this);
+
+        try {
+            $property = $reflectionClass->getProperty($key);
+        } catch (ReflectionException) {
+            return $default;
+        }
+
+        if (!$property->isPublic()) {
+            return $default;
+        }
+
+        return $property->getValue($this) ?: $default;
+    }
+
+    final public function set(string $key, mixed $value): ItemInterface
+    {
+        $reflectionClass = new ReflectionClass($this);
+
+        try {
+            $property = $reflectionClass->getProperty($key);
+        } catch (ReflectionException) {
+            throw new InvalidArgumentException(
+                \sprintf('No public property %s exists on class %s', $key, static::class),
+            );
+        }
+
+        if (!$property->isPublic()) {
+            throw new InvalidArgumentException(
+                \sprintf('No public property %s exists on class %s', $key, static::class),
+            );
+        }
+
+        $property->setValue($this, $value);
+
+        return $this;
+    }
+
+    final public function has(string $key): bool
+    {
+        $reflectionClass = new ReflectionClass($this);
+
+        try {
+            $property = $reflectionClass->getProperty($key);
+
+            return $property->isPublic();
+        } catch (ReflectionException) {
+            return false;
+        }
+    }
+
+    final public function offsetExists(mixed $offset): bool
+    {
+        return $this->has($offset);
+    }
+
+    final public function offsetGet(mixed $offset): mixed
+    {
+        /** @psalm-suppress MixedReturnStatement */
+        return $this->get($offset);
+    }
+
+    final public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->set($offset, $value);
+    }
+
+    final public function offsetUnset(mixed $offset): void
+    {
+        throw new RuntimeException('Unsetting properties is not supported for custom item classes');
+    }
+}

--- a/src/ItemPipeline/Item.php
+++ b/src/ItemPipeline/Item.php
@@ -45,23 +45,24 @@ final class Item implements ItemInterface
         return isset($this->data[$key]);
     }
 
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->data[$offset]);
     }
 
-    public function offsetGet($offset): mixed
+    public function offsetGet(mixed $offset): mixed
     {
         /** @psalm-suppress MixedReturnStatement */
         return $this->data[$offset];
     }
 
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
+        /** @psalm-suppress PossiblyNullArrayOffset */
         $this->data[$offset] = $value;
     }
 
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->data[$offset]);
     }

--- a/src/ItemPipeline/ItemPipeline.php
+++ b/src/ItemPipeline/ItemPipeline.php
@@ -15,6 +15,7 @@ namespace RoachPHP\ItemPipeline;
 
 use RoachPHP\Events\ItemDropped;
 use RoachPHP\Events\ItemScraped;
+use RoachPHP\ItemPipeline\Processors\ConditionalItemProcessor;
 use RoachPHP\ItemPipeline\Processors\ItemProcessorInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -39,6 +40,10 @@ final class ItemPipeline implements ItemPipelineInterface
     public function sendItem(ItemInterface $item): ItemInterface
     {
         foreach ($this->processors as $processor) {
+            if ($processor instanceof ConditionalItemProcessor && !$processor->shouldHandle($item)) {
+                continue;
+            }
+
             $item = $processor->processItem($item);
 
             if ($item->wasDropped()) {

--- a/src/ItemPipeline/Processors/ConditionalItemProcessor.php
+++ b/src/ItemPipeline/Processors/ConditionalItemProcessor.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2022 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/roach-php/roach
+ */
+
+namespace RoachPHP\ItemPipeline\Processors;
+
+use RoachPHP\ItemPipeline\ItemInterface;
+
+interface ConditionalItemProcessor extends ItemProcessorInterface
+{
+    /**
+     * Check if the yielded item should get handled by this item processor.
+     */
+    public function shouldHandle(ItemInterface $item): bool;
+}

--- a/src/ItemPipeline/Processors/CustomItemProcessor.php
+++ b/src/ItemPipeline/Processors/CustomItemProcessor.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2022 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/roach-php/roach
+ */
+
+namespace RoachPHP\ItemPipeline\Processors;
+
+use RoachPHP\ItemPipeline\ItemInterface;
+use RoachPHP\Support\Configurable;
+
+abstract class CustomItemProcessor implements ConditionalItemProcessor
+{
+    use Configurable;
+
+    final public function shouldHandle(ItemInterface $item): bool
+    {
+        return \in_array($item::class, $this->getHandledItemClasses(), true);
+    }
+
+    /**
+     * @return array<int, class-string<ItemInterface>>
+     */
+    abstract protected function getHandledItemClasses(): array;
+}

--- a/src/Spider/AbstractSpider.php
+++ b/src/Spider/AbstractSpider.php
@@ -16,6 +16,7 @@ namespace RoachPHP\Spider;
 use Generator;
 use RoachPHP\Http\Request;
 use RoachPHP\Http\Response;
+use RoachPHP\ItemPipeline\ItemInterface;
 use RoachPHP\Spider\Configuration\Configuration;
 
 abstract class AbstractSpider implements SpiderInterface
@@ -66,8 +67,12 @@ abstract class AbstractSpider implements SpiderInterface
         return ParseResult::request($method, $url, [$this, $parseMethod], $options);
     }
 
-    protected function item(array $item): ParseResult
+    protected function item(ItemInterface|array $item): ParseResult
     {
+        if ($item instanceof ItemInterface) {
+            return ParseResult::fromValue($item);
+        }
+
         return ParseResult::item($item);
     }
 

--- a/tests/Fixtures/TestCustomItemProcessor.php
+++ b/tests/Fixtures/TestCustomItemProcessor.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2022 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/roach-php/roach
+ */
+
+namespace RoachPHP\Tests\Fixtures;
+
+use RoachPHP\ItemPipeline\ItemInterface;
+use RoachPHP\ItemPipeline\Processors\CustomItemProcessor;
+
+final class TestCustomItemProcessor extends CustomItemProcessor
+{
+    /**
+     * @param array<int, class-string<ItemInterface>> $handledItemClasses
+     */
+    public function __construct(private array $handledItemClasses)
+    {
+    }
+
+    public function processItem(ItemInterface $item): ItemInterface
+    {
+        return $item->drop('::reason::');
+    }
+
+    protected function getHandledItemClasses(): array
+    {
+        return $this->handledItemClasses;
+    }
+}

--- a/tests/Fixtures/TestItem.php
+++ b/tests/Fixtures/TestItem.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2022 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/roach-php/roach
+ */
+
+namespace RoachPHP\Tests\Fixtures;
+
+use RoachPHP\ItemPipeline\AbstractItem;
+
+final class TestItem extends AbstractItem
+{
+    protected string $baz = 'baz';
+
+    private string $qux = 'qux';
+
+    public function __construct(public string $foo, public ?string $bar)
+    {
+    }
+}

--- a/tests/Fixtures/TestItem2.php
+++ b/tests/Fixtures/TestItem2.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2022 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/roach-php/roach
+ */
+
+namespace RoachPHP\Tests\Fixtures;
+
+use RoachPHP\ItemPipeline\AbstractItem;
+
+final class TestItem2 extends AbstractItem
+{
+}

--- a/tests/ItemPipeline/AbstractItemTest.php
+++ b/tests/ItemPipeline/AbstractItemTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2022 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/roach-php/roach
+ */
+
+namespace RoachPHP\Tests\ItemPipeline;
+
+use Generator;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use RoachPHP\Tests\Fixtures\TestItem;
+use RuntimeException;
+
+/**
+ * @internal
+ */
+final class AbstractItemTest extends TestCase
+{
+    public function testCanGetPublicProperty(): void
+    {
+        $item = new TestItem(foo: '::value-1::', bar: '::value-2::');
+
+        self::assertSame('::value-1::', $item->get('foo'));
+        self::assertSame('::value-2::', $item->get('bar'));
+    }
+
+    public function testReturnDefaultValueIfNoPublicPropertyExistsForName(): void
+    {
+        $item = new TestItem(foo: '::value-1::', bar: '::value-2::');
+
+        self::assertSame('::default::', $item->get('baz', '::default::'));
+        self::assertSame('::default::', $item->get('qux', '::default::'));
+        self::assertSame('::default::', $item->get('lorem-ipsum', '::default::'));
+    }
+
+    public function testReturnDefaultValueIfPropertyIsNull(): void
+    {
+        $item = new TestItem(foo: '::value::', bar: null);
+
+        self::assertSame('::default::', $item->get('bar', '::default::'));
+    }
+
+    public function testCanGetAllPublicProperties(): void
+    {
+        $item = new TestItem(foo: '::value-1::', bar: '::value-2::');
+
+        self::assertEquals([
+            'foo' => '::value-1::',
+            'bar' => '::value-2::',
+        ], $item->all());
+    }
+
+    public function testCanSetPublicProperty(): void
+    {
+        $item = new TestItem(foo: '::old-value-1::', bar: '::old-value-2::');
+
+        $item->set('foo', '::new-value-1::');
+        $item->set('bar', '::new-value-2::');
+
+        self::assertSame('::new-value-1::', $item->foo);
+        self::assertSame('::new-value-2::', $item->bar);
+    }
+
+    /**
+     * @dataProvider inaccessiblePropertiesProvider
+     */
+    public function testThrowsExceptionWhenTryingToSetNonPublicOrNonExistentProperty(string $property): void
+    {
+        $item = new TestItem(foo: '::old-value-1::', bar: '::old-value-2::');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("No public property {$property} exists on class RoachPHP\\Tests\\Fixtures\\TestItem");
+        $item->set($property, '::new-value::');
+    }
+
+    /**
+     * @dataProvider hasPropertyProvider
+     */
+    public function testHasProperty(string $property, bool $expected): void
+    {
+        $item = new TestItem(foo: '::value-1::', bar: '::value-2::');
+
+        self::assertSame($expected, $item->has($property));
+    }
+
+    /**
+     * @dataProvider hasPropertyProvider
+     */
+    public function testOffsetExists(string $property, bool $expected): void
+    {
+        $item = new TestItem(foo: '::value-1::', bar: '::value-2::');
+
+        self::assertSame($expected, isset($item[$property]));
+    }
+
+    public function hasPropertyProvider(): Generator
+    {
+        yield from [
+            'public property 1' => ['foo', true],
+            'public property 2' => ['bar', true],
+            'protected property' => ['baz', false],
+            'private property' => ['qux', false],
+            'non-existent property' => ['does-not-exist', false],
+        ];
+    }
+
+    public function testOffsetGetCanRetrievePublicProperties(): void
+    {
+        $item = new TestItem(foo: '::value-1::', bar: '::value-2::');
+
+        self::assertSame('::value-1::', $item['foo']);
+        self::assertSame('::value-2::', $item['bar']);
+    }
+
+    public function testOffsetGetReturnsNullForNonAccessibleProperty(): void
+    {
+        $item = new TestItem(foo: '::value-1::', bar: '::value-2::');
+
+        self::assertNull($item['baz']);
+        self::assertNull($item['qux']);
+    }
+
+    public function testOffsetGetReturnsNullForNonExistentProperty(): void
+    {
+        $item = new TestItem(foo: '::value-1::', bar: '::value-2::');
+
+        self::assertNull($item['does-not-exist']);
+    }
+
+    public function testOffsetSetCanSetPublicProperties(): void
+    {
+        $item = new TestItem(foo: '::old-value-1::', bar: '::old-value-2::');
+
+        $item['foo'] = '::new-value-1::';
+        $item['bar'] = '::new-value-2::';
+
+        self::assertSame('::new-value-1::', $item->foo);
+        self::assertSame('::new-value-2::', $item->bar);
+    }
+
+    /**
+     * @dataProvider inaccessiblePropertiesProvider
+     */
+    public function testOffsetSetThrowsExceptionWhenSettingInaccessibleOrNonExistentProperty(string $property): void
+    {
+        $item = new TestItem(foo: '::value-1::', bar: '::value-2::');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("No public property {$property} exists on class RoachPHP\\Tests\\Fixtures\\TestItem");
+
+        $item[$property] = '::new-value::';
+    }
+
+    public function inaccessiblePropertiesProvider(): Generator
+    {
+        yield from [
+            'protected property' => ['baz'],
+            'private property' => ['qux'],
+            'non-existent property' => ['does-not-exist'],
+        ];
+    }
+
+    public function testDoesNotSupportUnsettingProperties(): void
+    {
+        $item = new TestItem(foo: '::value-1::', bar: '::value-2::');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsetting properties is not supported for custom item classes');
+
+        unset($item['foo']);
+    }
+}

--- a/tests/ItemPipeline/AbstractItemTest.php
+++ b/tests/ItemPipeline/AbstractItemTest.php
@@ -135,6 +135,16 @@ final class AbstractItemTest extends TestCase
         self::assertNull($item['does-not-exist']);
     }
 
+    public function testOffsetGetThrowsExceptionIfOffsetIsNotAString(): void
+    {
+        $item = new TestItem(foo: '::value-1::', bar: '::value-2::');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Offset needs to be a string');
+
+        $item[0];
+    }
+
     public function testOffsetSetCanSetPublicProperties(): void
     {
         $item = new TestItem(foo: '::old-value-1::', bar: '::old-value-2::');
@@ -166,6 +176,16 @@ final class AbstractItemTest extends TestCase
             'private property' => ['qux'],
             'non-existent property' => ['does-not-exist'],
         ];
+    }
+
+    public function testOffsetSetThrowsExceptionIfOffsetIsNotAString(): void
+    {
+        $item = new TestItem(foo: '::value-1::', bar: '::value-2::');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Offset needs to be a string');
+
+        $item[0] = '::value::';
     }
 
     public function testDoesNotSupportUnsettingProperties(): void

--- a/tests/ItemPipeline/CustomItemProcessorTest.php
+++ b/tests/ItemPipeline/CustomItemProcessorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2022 Kai Sassnowski
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/roach-php/roach
+ */
+
+namespace RoachPHP\Tests\ItemPipeline;
+
+use PHPUnit\Framework\TestCase;
+use RoachPHP\Tests\Fixtures\TestCustomItemProcessor;
+use RoachPHP\Tests\Fixtures\TestItem;
+use RoachPHP\Tests\Fixtures\TestItem2;
+
+/**
+ * @internal
+ */
+final class CustomItemProcessorTest extends TestCase
+{
+    public function testHandlesItemsDefinedByTheChildClass(): void
+    {
+        $processor = new TestCustomItemProcessor([TestItem::class]);
+        self::assertTrue(
+            $processor->shouldHandle(new TestItem('::foo::', '::bar::')),
+        );
+
+        $processor = new TestCustomItemProcessor([TestItem2::class]);
+        self::assertTrue(
+            $processor->shouldHandle(new TestItem2()),
+        );
+    }
+
+    public function testDoesNotHandleItemsNotDefinedInTheChildClass(): void
+    {
+        $processor = new TestCustomItemProcessor([TestItem::class]);
+        self::assertFalse(
+            $processor->shouldHandle(new TestItem2()),
+        );
+
+        $processor = new TestCustomItemProcessor([TestItem2::class]);
+        self::assertFalse(
+            $processor->shouldHandle(new TestItem('::foo::', '::bar::')),
+        );
+    }
+}


### PR DESCRIPTION
This PR adds the ability to define custom item classes and and an option for item processors to only process certain items.

## Custom Items

Custom items are simple PHP objects which extend the `RoachPHP\ItemPipeline\AbstractItem` class. The `AbstractItem` class implements all necessary interfaces in order to stand in for any other kind of item.

```php
final class Team extends AbstractItem
{
    public function __construct(
        public readonly UuidInterface $id,
        public readonly string $name,
    ) {
    }
}
```

To yield a custom item from a spider, we can continue to use the spider's `item` method. Instead of passing in array, however, we pass in an instance of our custom item class.

```php
public function parse(Response $response): Generator
{
    // Do some processing...
    yield $this->item(new MyCustomItem($id, $name));
}
```

This can already be nice on its own if we want to structure our scraped data a little more instead of passing around raw arrays. The real value comes from combining this with the next feature, however: custom item processors.

## Custom Item Processors

Up until now, every processor of a spider would run for each yielded item. This can become problematic if our spider yields multiple different types of data from the same parse callback. 

Say we're parsing a match summary of a football match. We might want to yield a `Team` item for both the home and the away team. The teams should get saved to the database so we can reference them later when we store the matches themselves. However, we also want to yield a `FootballMatch` item containing the information about the match itself. 

The issue now is that we probably want to process the two types of items completely differently. The only way to deal with this at the moment is to add `if-else` blocks to all of our processors to manually check which kind of item we're dealing with. This is really cumbersome because it often requires us to add additional metadata to our items for the sole purpose of being able to tell which kind of item we're dealing with in our processor.

This PR introduces a new `ConditionalItemProcessor` interface as well as a `CustomItemProcessor` base class. The `ConditionalItemProcessor` interface describes a processor which may not run for each yielded item.

```php
interface ConditionalItemProcessor
{
    /**
     * Check if the yielded item should get handled by this item processor.
     */
    public function shouldHandle(ItemInterface $item): bool;
}
```

The item pipeline will call the `shouldHandle` method of each processor that implements the `ConditionalItemProcessor` interface to check if this processor should handle the item.

The `CustomItemProcessor` base class is a convenience to handle one of the most common cases why we might do this: handling only a certain type of item. To create a processor like this, we extend the `ConditionalItemProcessor` class and implement the `getHandledItemClasses` as well as the usual `processItem` methods.

```php
final class SaveTeamToDatabaseProcessor extends CustomItemProcessor
{
    /**
     * @param Team $item
     */
    public function processItem(ItemInterface $item): ItemInterface
    {
         // Process the item. Note how we can now narrow the type hint for `$item`
         // since we know that this processor will never get called for a different
         // type of item.
    }

    /**
     * @return array<int, class-string<ItemInterface>>
     */
    protected function getHandledItemClasses(): array
    {
        // Team is the custom item we defined above.
        return [Team::class];
    }
}
```

We can then define a separate item processor to only process `FootballMatch` items. We register these processors just like any other processor.

```php
class MySpider extends BasicSpider
{
    public array $itemProcessors = [
        SaveTeamToDatabaseProcessor::class,
        SaveMatchToDatabaseProcessor::class,
    ];
}
```

**Note:** Custom processors _only_ process the item types defined in the `getHandledItemClasses` method. This means that non-custom items don't get processed.