### PR TITLE
Add possibility to configure Run with entire Downloader, ItemPipeline and Processor objects

### DIFF
--- a/src/Core/Engine.php
+++ b/src/Core/Engine.php
@@ -144,9 +144,24 @@ final class Engine implements EngineInterface
     private function configure(Run $run): void
     {
         $this->scheduler->setDelay($run->requestDelay);
-        $this->itemPipeline->setProcessors(...$run->itemProcessors);
-        $this->downloader->withMiddleware(...$run->downloaderMiddleware);
-        $this->responseProcessor->withMiddleware(...$run->responseMiddleware);
+
+        if (null !== $run->itemPipeline) {
+            $this->itemPipeline = $run->itemPipeline;
+        } else {
+            $this->itemPipeline->setProcessors(...$run->itemProcessors);
+        }
+
+        if (null !== $run->downloader) {
+            $this->downloader = $run->downloader;
+        } else {
+            $this->downloader->withMiddleware(...$run->downloaderMiddleware);
+        }
+
+        if (null !== $run->responseProcessor) {
+            $this->responseProcessor = $run->responseProcessor;
+        } else {
+            $this->responseProcessor->withMiddleware(...$run->responseMiddleware);
+        }
 
         foreach ($run->extensions as $extension) {
             $this->eventDispatcher->addSubscriber($extension);

--- a/src/Core/Run.php
+++ b/src/Core/Run.php
@@ -13,10 +13,13 @@ declare(strict_types=1);
 
 namespace RoachPHP\Core;
 
+use RoachPHP\Downloader\Downloader;
 use RoachPHP\Downloader\DownloaderMiddlewareInterface;
 use RoachPHP\Extensions\ExtensionInterface;
 use RoachPHP\Http\Request;
+use RoachPHP\ItemPipeline\ItemPipelineInterface;
 use RoachPHP\ItemPipeline\Processors\ItemProcessorInterface;
+use RoachPHP\Spider\Processor;
 use RoachPHP\Spider\SpiderMiddlewareInterface;
 
 /**
@@ -30,6 +33,9 @@ final class Run
      * @param ItemProcessorInterface[]        $itemProcessors
      * @param SpiderMiddlewareInterface[]     $responseMiddleware
      * @param ExtensionInterface[]            $extensions
+     * @param null|Downloader                 $downloader
+     * @param null|ItemPipelineInterface      $itemPipeline
+     * @param null|Processor                  $responseProcessor
      */
     public function __construct(
         public array $startRequests,
@@ -39,6 +45,9 @@ final class Run
         public array $extensions = [],
         public int $concurrency = 25,
         public int $requestDelay = 0,
+        public ?Downloader $downloader = null,
+        public ?ItemPipelineInterface $itemPipeline = null,
+        public ?Processor $responseProcessor = null,
     ) {
     }
 }


### PR DESCRIPTION
The purpose of this PR is to create re-usable configurations for Downloader, ItemPipeline and Processor objects.

I use roach with Symfony bundle https://github.com/Ne-Lexa/roach-php-bundle and now I have to duplicate pipeline and middleware configurations for different spiders in my application. I think, that my proposal can avoid duplicating this:

```   
    roach.run.first:
        parent: roach.run.base
        arguments:
            $downloaderMiddleware:
                - '@roach.downloader_middleware.first'
                - '@roach.downloader_middleware.second'
            $itemProcessors:
                - '@roach.item_processor.first'
                - '@roach.item_processor.second'
                
    roach.run.second:
        parent: roach.run.base
        arguments:
            $downloaderMiddleware:
                - '@roach.downloader_middleware.first'
                - '@roach.downloader_middleware.second'
            $itemProcessors:
                - '@roach.item_processor.first'
                - '@roach.item_processor.second'
```

and allows this:

```
    roach.downloader: ~
    roach.item_pipeline: ~

    roach.run.first:
        arguments:
            $downloader: '@roach.downloader'
            $itemPipepine: '@roach.item_pipeline'
```

To avoid BC-break I have extended Run fields and add a possibility to configure the Engine both with an array of middlewares/processors and an entire instances of Downloader/ItemPipeline/Processor. 