### PR TITLE
Adds option for setDelay on ExecuteJavascriptMiddleware

### DIFF
--- a/src/Downloader/Middleware/ExecuteJavascriptMiddleware.php
+++ b/src/Downloader/Middleware/ExecuteJavascriptMiddleware.php
@@ -94,6 +94,10 @@ final class ExecuteJavascriptMiddleware implements ResponseMiddlewareInterface
             $browsershot->setNpmBinary($npmBinary);
         }
 
+        if (!empty($delay = $this->option('delay'))) {
+            $browsershot->setDelay($delay);
+        }
+
         return $browsershot;
     }
 
@@ -107,6 +111,7 @@ final class ExecuteJavascriptMiddleware implements ResponseMiddlewareInterface
             'includePath' => null,
             'nodeBinary' => null,
             'npmBinary' => null,
+            'delay' => 0,
         ];
     }
 }


### PR DESCRIPTION
I have a need to wait for a request on a page with javascript. The setDelay option was needed to be able to read the page data.