### PR TITLE
feat: add namespace to scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .phpunit.result.cache
 .phpunit.cache/
 /coverage/
+/package-lock.json
+/package.json
+/node_modules

--- a/src/Core/Engine.php
+++ b/src/Core/Engine.php
@@ -61,8 +61,10 @@ final class Engine implements EngineInterface
             RunStarting::NAME,
         );
 
-        foreach ($run->startRequests as $request) {
-            $this->scheduleRequest($request);
+        if ($this->scheduler->empty()) {
+            foreach ($run->startRequests as $request) {
+                $this->scheduleRequest($request);
+            }
         }
 
         $this->work($run);
@@ -144,6 +146,7 @@ final class Engine implements EngineInterface
     private function configure(Run $run): void
     {
         $this->scheduler->setDelay($run->requestDelay);
+        $this->scheduler->setNamespace($run->namespace);
         $this->itemPipeline->setProcessors(...$run->itemProcessors);
         $this->downloader->withMiddleware(...$run->downloaderMiddleware);
         $this->responseProcessor->withMiddleware(...$run->responseMiddleware);

--- a/src/Core/Run.php
+++ b/src/Core/Run.php
@@ -33,6 +33,7 @@ final class Run
      */
     public function __construct(
         public array $startRequests,
+        public string $namespace,
         public array $downloaderMiddleware = [],
         public array $itemProcessors = [],
         public array $responseMiddleware = [],

--- a/src/Core/RunFactory.php
+++ b/src/Core/RunFactory.php
@@ -40,6 +40,7 @@ final class RunFactory
 
         return new Run(
             $spider->getInitialRequests(),
+            $spider::class,
             $this->buildDownloaderMiddleware($configuration->downloaderMiddleware),
             $this->buildItemPipeline($configuration->itemProcessors),
             $this->buildResponseMiddleware($configuration->spiderMiddleware),

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -115,4 +115,9 @@ final class Request implements DroppableInterface
     {
         return $this->psrRequest;
     }
+
+    public function getParseCallback(): Closure
+    {
+        return $this->parseCallback;
+    }
 }

--- a/src/Scheduling/ArrayRequestScheduler.php
+++ b/src/Scheduling/ArrayRequestScheduler.php
@@ -68,6 +68,11 @@ final class ArrayRequestScheduler implements RequestSchedulerInterface
         return $this;
     }
 
+    public function setNamespace(string $namespace): RequestSchedulerInterface
+    {
+        return $this;
+    }
+
     private function updateNextBatchTime(): void
     {
         $this->nextBatchReadyAt = $this->clock->now()->add(new DateInterval("PT{$this->delay}S"));

--- a/src/Scheduling/RequestSchedulerInterface.php
+++ b/src/Scheduling/RequestSchedulerInterface.php
@@ -38,4 +38,6 @@ interface RequestSchedulerInterface
     public function empty(): bool;
 
     public function setDelay(int $delay): self;
+
+    public function setNamespace(string $namespace): self;
 }

--- a/tests/Core/EngineTest.php
+++ b/tests/Core/EngineTest.php
@@ -72,7 +72,7 @@ final class EngineTest extends IntegrationTestCase
             $this->makeRequest('http://localhost:8000/test1'),
             $this->makeRequest('http://localhost:8000/test2'),
         ];
-        $run = new Run($startRequests);
+        $run = new Run($startRequests, 'DefaultSpider');
 
         $this->engine->start($run);
 
@@ -89,6 +89,7 @@ final class EngineTest extends IntegrationTestCase
         };
         $run = new Run(
             [$this->makeRequest('http://localhost:8000/test2', $parseFunction)],
+            'DefaultSpider',
         );
 
         $this->engine->start($run);
@@ -108,6 +109,7 @@ final class EngineTest extends IntegrationTestCase
         };
         $run = new Run(
             [$this->makeRequest('http://localhost:8000/test1', $parseCallback)],
+            'DefaultSpider',
         );
 
         $this->engine->start($run);
@@ -127,6 +129,7 @@ final class EngineTest extends IntegrationTestCase
         ];
         $run = new Run(
             $startRequests,
+            'DefaultSpider',
             itemProcessors: [$processor],
         );
 
@@ -145,6 +148,7 @@ final class EngineTest extends IntegrationTestCase
         };
         $run = new Run(
             [$this->makeRequest('http://localhost:8000/test1', $parseCallback)],
+            'DefaultSpider',
             itemProcessors: [$processor],
         );
 
@@ -163,6 +167,7 @@ final class EngineTest extends IntegrationTestCase
         };
         $run = new Run(
             [$this->makeRequest('http://localhost:8000/test1', $parseCallback)],
+            'DefaultSpider',
             extensions: [
                 new StatsCollectorExtension($logger, new FakeClock()),
                 new LoggerExtension($logger),
@@ -197,6 +202,7 @@ final class EngineTest extends IntegrationTestCase
         };
         $run = new Run(
             [$this->makeRequest('http://localhost:8000/test1', $parseCallback)],
+            'DefaultSpider',
         );
 
         $result = $this->engine->collect($run);
@@ -228,6 +234,7 @@ final class EngineTest extends IntegrationTestCase
                 $this->makeRequest('http://localhost:8000/test3'),
                 $this->makeRequest('http://localhost:8000/robots'),
             ],
+            'DefaultSpider',
             downloaderMiddleware: [DownloaderMiddlewareAdapter::fromMiddleware($middleware)],
             concurrency: 1,
             requestDelay: 5,

--- a/tests/Core/RunFactoryTest.php
+++ b/tests/Core/RunFactoryTest.php
@@ -224,6 +224,15 @@ final class RunFactoryTest extends TestCase
         self::assertSame($requestDelay, $run->requestDelay);
     }
 
+    public function testConfigureRunNamespace(): void
+    {
+        $spider = $this->createSpider();
+
+        $run = $this->factory->fromSpider($spider);
+
+        self::assertSame($spider::class, $run->namespace);
+    }
+
     public static function numberProvider(): Generator
     {
         yield from [

--- a/tests/Downloader/Middleware/RobotsTxtMiddlewareTest.php
+++ b/tests/Downloader/Middleware/RobotsTxtMiddlewareTest.php
@@ -64,6 +64,7 @@ final class RobotsTxtMiddlewareTest extends IntegrationTestCase
         $parseCallback = static fn () => yield ParseResult::fromValue(self::makeRequest('http://localhost:8000/test2'));
         $run = new Run(
             [new Request('GET', 'http://localhost:8000/test1', $parseCallback)],
+            '::namespace::',
             downloaderMiddleware: [$this->middleware],
         );
 
@@ -76,6 +77,7 @@ final class RobotsTxtMiddlewareTest extends IntegrationTestCase
     {
         $run = new Run(
             [self::makeRequest('http://localhost:8000/test1')],
+            '::namespace::',
             downloaderMiddleware: [$this->middleware],
         );
 
@@ -88,6 +90,7 @@ final class RobotsTxtMiddlewareTest extends IntegrationTestCase
     {
         $run = new Run(
             [self::makeRequest('http://localhost:8000/test2')],
+            '::namespace::',
             downloaderMiddleware: [$this->middleware],
         );
 

--- a/tests/Extensions/LoggerExtensionTest.php
+++ b/tests/Extensions/LoggerExtensionTest.php
@@ -44,7 +44,7 @@ final class LoggerExtensionTest extends ExtensionTestCase
             $this->logger->messageWasLogged('info', 'Run starting'),
         );
 
-        $this->dispatch(new RunStarting(new Run([], 'DefaultSpider')), RunStarting::NAME);
+        $this->dispatch(new RunStarting(new Run([], '::namespace::')), RunStarting::NAME);
 
         self::assertTrue(
             $this->logger->messageWasLogged('info', 'Run starting'),
@@ -57,7 +57,7 @@ final class LoggerExtensionTest extends ExtensionTestCase
             $this->logger->messageWasLogged('info', 'Run finished'),
         );
 
-        $this->dispatch(new RunFinished(new Run([], 'DefaultSpider')), RunFinished::NAME);
+        $this->dispatch(new RunFinished(new Run([], '::namespace::')), RunFinished::NAME);
 
         self::assertTrue(
             $this->logger->messageWasLogged('info', 'Run finished'),

--- a/tests/Extensions/LoggerExtensionTest.php
+++ b/tests/Extensions/LoggerExtensionTest.php
@@ -44,7 +44,7 @@ final class LoggerExtensionTest extends ExtensionTestCase
             $this->logger->messageWasLogged('info', 'Run starting'),
         );
 
-        $this->dispatch(new RunStarting(new Run([])), RunStarting::NAME);
+        $this->dispatch(new RunStarting(new Run([], 'DefaultSpider')), RunStarting::NAME);
 
         self::assertTrue(
             $this->logger->messageWasLogged('info', 'Run starting'),
@@ -57,7 +57,7 @@ final class LoggerExtensionTest extends ExtensionTestCase
             $this->logger->messageWasLogged('info', 'Run finished'),
         );
 
-        $this->dispatch(new RunFinished(new Run([])), RunFinished::NAME);
+        $this->dispatch(new RunFinished(new Run([], 'DefaultSpider')), RunFinished::NAME);
 
         self::assertTrue(
             $this->logger->messageWasLogged('info', 'Run finished'),

--- a/tests/Extensions/StatsCollectorExtensionTest.php
+++ b/tests/Extensions/StatsCollectorExtensionTest.php
@@ -130,7 +130,7 @@ final class StatsCollectorExtensionTest extends ExtensionTestCase
      */
     private function withRun(callable $callback): void
     {
-        $run = new Run([]);
+        $run = new Run([], 'DefaultSpider');
 
         $this->dispatch(new RunStarting($run), RunStarting::NAME);
 

--- a/tests/Extensions/StatsCollectorExtensionTest.php
+++ b/tests/Extensions/StatsCollectorExtensionTest.php
@@ -130,7 +130,7 @@ final class StatsCollectorExtensionTest extends ExtensionTestCase
      */
     private function withRun(callable $callback): void
     {
-        $run = new Run([], 'DefaultSpider');
+        $run = new Run([], '::namespace::');
 
         $this->dispatch(new RunStarting($run), RunStarting::NAME);
 


### PR DESCRIPTION
Kept it simple by just adding a namespace to the scheduler interface and setting it in the engine. I added a parseCallback getter method so the user can get the callback and serialize it themselves, leaving the implementation up to them instead of you having to figure it out.