### PR TITLE
Update ExecuteJavascriptMiddleware.php by allowing config of waitUntilNetworkIdle()

### DIFF
--- a/src/Downloader/Middleware/ExecuteJavascriptMiddleware.php
+++ b/src/Downloader/Middleware/ExecuteJavascriptMiddleware.php
@@ -36,7 +36,7 @@ final class ExecuteJavascriptMiddleware implements ResponseMiddlewareInterface
         ?callable $getBrowsershot = null,
     ) {
         /** @psalm-suppress MixedInferredReturnType, MixedReturnStatement */
-        $this->getBrowsershot = $getBrowsershot ?: static fn (string $uri): Browsershot => Browsershot::url($uri)->waitUntilNetworkIdle();
+        $this->getBrowsershot = $getBrowsershot ?: static fn (string $uri): Browsershot => Browsershot::url($uri);
     }
 
     public function handleResponse(Response $response): Response
@@ -65,6 +65,10 @@ final class ExecuteJavascriptMiddleware implements ResponseMiddlewareInterface
     private function configureBrowsershot(string $uri): Browsershot
     {
         $browsershot = ($this->getBrowsershot)($uri);
+
+        if (null !== ($waitUntilNetworkIdle = $this->option('waitUntilNetworkIdle'))) {
+            $browsershot->waitUntilNetworkIdle($waitUntilNetworkIdle);
+        }
 
         if (!empty($this->option('chromiumArguments'))) {
             $browsershot->addChromiumArguments($this->option('chromiumArguments'));
@@ -108,6 +112,7 @@ final class ExecuteJavascriptMiddleware implements ResponseMiddlewareInterface
     private function defaultOptions(): array
     {
         return [
+            'waitUntilNetworkIdle' => true,
             'chromiumArguments' => [],
             'chromePath' => null,
             'binPath' => null,


### PR DESCRIPTION
This pull request introduces an additional improvement to #56 by allowing the configuration of `waitUntilNetworkIdle()`. The previous implementation assumed the true statement, making it impossible to overwrite this behavior without duplicating the class, which I ran into for a particular project.

To address this, a new config variable called `waitUntilNetworkIdle` has been introduced. By default, the config is set to true to maintain backward compatibility with the original pull request. However, you now have the flexibility to overwrite the setting and set it to false.