### PR TITLE
fix: fix race condition in SystemClock

### DIFF
--- a/src/Scheduling/Timing/SystemClock.php
+++ b/src/Scheduling/Timing/SystemClock.php
@@ -32,13 +32,14 @@ final class SystemClock implements ClockInterface
 
     public function sleepUntil(DateTimeImmutable $date): void
     {
-        $now = $this->now();
+        $now = $this->now()->getTimestamp();
+        $target = $date->getTimestamp();
 
-        if ($now >= $date) {
+        if ($target <= $now) {
             return;
         }
 
         /** @psalm-suppress UnusedFunctionCall */
-        \time_sleep_until($date->getTimestamp());
+        \time_sleep_until($target);
     }
 }


### PR DESCRIPTION
Fixes #201

The problem is that when comparing `DateTimeImmutable` objects directly with `<=`, they get compared on a millisecond level. This can lead to a race condition where by the time we reach the `time_sleep_until` line, the target date is now in the future.