### PR TITLE
fix: added missing response middleware dropped event

### DIFF
--- a/src/Downloader/Downloader.php
+++ b/src/Downloader/Downloader.php
@@ -132,6 +132,11 @@ final class Downloader
             $response = $middleware->handleResponse($response);
 
             if ($response->wasDropped()) {
+                $this->eventDispatcher->dispatch(
+                    new ResponseDropped($response),
+                    ResponseDropped::NAME,
+                );
+
                 return;
             }
         }


### PR DESCRIPTION
When a response middleware in the Downloader was dropped no event was dispatched. The documentation mentions this should happen. This code adds the event and tests to test this.