### PR TITLE
Feat: Exception handling

### DIFF
--- a/src/Downloader/Downloader.php
+++ b/src/Downloader/Downloader.php
@@ -57,7 +57,7 @@ final class Downloader
         return \count($this->requests);
     }
 
-    public function prepare(Request $request, ?callable $onRejected): void
+    public function prepare(Request $request, ?callable $onRejected = null): void
     {
         try {
             foreach ($this->middleware as $middleware) {

--- a/src/Downloader/Downloader.php
+++ b/src/Downloader/Downloader.php
@@ -180,13 +180,8 @@ final class Downloader
             ExceptionReceiving::NAME,
         );
 
-        $handled = false;
         foreach ($this->middleware as $middleware) {
-            $middleware->handleException($requestException);
-
-            if ($requestException->isHandled()) {
-                $handled = true;
-            }
+            $requestException = $middleware->handleException($requestException);
         }
 
         $this->eventDispatcher->dispatch(
@@ -197,7 +192,7 @@ final class Downloader
         if (null !== $callback) {
             $callback($requestException);
 
-        } else if (!$handled) {
+        } else if (!$requestException->isHandled()) {
             throw $requestException;
         }
     }

--- a/src/Downloader/Downloader.php
+++ b/src/Downloader/Downloader.php
@@ -180,8 +180,13 @@ final class Downloader
             ExceptionReceiving::NAME,
         );
 
+        $handled = false;
         foreach ($this->middleware as $middleware) {
             $middleware->handleException($requestException);
+
+            if ($requestException->isHandled()) {
+                $handled = true;
+            }
         }
 
         $this->eventDispatcher->dispatch(
@@ -191,6 +196,9 @@ final class Downloader
 
         if (null !== $callback) {
             $callback($requestException);
+
+        } else if (!$handled) {
+            throw $requestException;
         }
     }
 }

--- a/src/Downloader/DownloaderMiddlewareInterface.php
+++ b/src/Downloader/DownloaderMiddlewareInterface.php
@@ -13,9 +13,10 @@ declare(strict_types=1);
 
 namespace RoachPHP\Downloader;
 
+use RoachPHP\Downloader\Middleware\ExceptionMiddlewareInterface;
 use RoachPHP\Downloader\Middleware\RequestMiddlewareInterface;
 use RoachPHP\Downloader\Middleware\ResponseMiddlewareInterface;
 
-interface DownloaderMiddlewareInterface extends RequestMiddlewareInterface, ResponseMiddlewareInterface
+interface DownloaderMiddlewareInterface extends RequestMiddlewareInterface, ResponseMiddlewareInterface, ExceptionMiddlewareInterface
 {
 }

--- a/src/Downloader/Middleware/DownloaderMiddlewareAdapter.php
+++ b/src/Downloader/Middleware/DownloaderMiddlewareAdapter.php
@@ -16,6 +16,7 @@ namespace RoachPHP\Downloader\Middleware;
 use Exception;
 use RoachPHP\Downloader\DownloaderMiddlewareInterface;
 use RoachPHP\Http\Request;
+use RoachPHP\Http\RequestException;
 use RoachPHP\Http\Response;
 
 /**
@@ -56,13 +57,13 @@ final class DownloaderMiddlewareAdapter implements DownloaderMiddlewareInterface
         return $response;
     }
 
-    public function handleException(Exception $exception, Request $request): ?Request
+    public function handleException(RequestException $requestException): RequestException
     {
         if ($this->middleware instanceof ExceptionMiddlewareInterface) {
-            return $this->middleware->handleException($exception, $request);
+            return $this->middleware->handleException($requestException);
         }
 
-        return $request;
+        return $requestException;
     }
 
     public function configure(array $options): void

--- a/src/Downloader/Middleware/DownloaderMiddlewareAdapter.php
+++ b/src/Downloader/Middleware/DownloaderMiddlewareAdapter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace RoachPHP\Downloader\Middleware;
 
+use Exception;
 use RoachPHP\Downloader\DownloaderMiddlewareInterface;
 use RoachPHP\Http\Request;
 use RoachPHP\Http\Response;
@@ -23,12 +24,12 @@ use RoachPHP\Http\Response;
 final class DownloaderMiddlewareAdapter implements DownloaderMiddlewareInterface
 {
     private function __construct(
-        private RequestMiddlewareInterface|ResponseMiddlewareInterface $middleware,
+        private RequestMiddlewareInterface|ResponseMiddlewareInterface|ExceptionMiddlewareInterface $middleware,
     ) {
     }
 
     public static function fromMiddleware(
-        RequestMiddlewareInterface|ResponseMiddlewareInterface $middleware,
+        RequestMiddlewareInterface|ResponseMiddlewareInterface|ExceptionMiddlewareInterface $middleware,
     ): DownloaderMiddlewareInterface {
         if ($middleware instanceof DownloaderMiddlewareInterface) {
             return $middleware;
@@ -55,12 +56,21 @@ final class DownloaderMiddlewareAdapter implements DownloaderMiddlewareInterface
         return $response;
     }
 
+    public function handleException(Exception $exception, Request $request): ?Request
+    {
+        if ($this->middleware instanceof ExceptionMiddlewareInterface) {
+            return $this->middleware->handleException($exception, $request);
+        }
+
+        return $request;
+    }
+
     public function configure(array $options): void
     {
         $this->middleware->configure($options);
     }
 
-    public function getMiddleware(): RequestMiddlewareInterface|ResponseMiddlewareInterface
+    public function getMiddleware(): RequestMiddlewareInterface|ResponseMiddlewareInterface|ExceptionMiddlewareInterface
     {
         return $this->middleware;
     }

--- a/src/Downloader/Middleware/ExceptionMiddlewareInterface.php
+++ b/src/Downloader/Middleware/ExceptionMiddlewareInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoachPHP\Downloader\Middleware;
+
+use Exception;
+use RoachPHP\Http\Request;
+use RoachPHP\Support\ConfigurableInterface;
+
+interface ExceptionMiddlewareInterface extends ConfigurableInterface
+{
+    public function handleException(Exception $exception, Request $request): ?Request;
+}

--- a/src/Downloader/Middleware/ExceptionMiddlewareInterface.php
+++ b/src/Downloader/Middleware/ExceptionMiddlewareInterface.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace RoachPHP\Downloader\Middleware;
 
-use Exception;
-use RoachPHP\Http\Request;
+use RoachPHP\Http\RequestException;
 use RoachPHP\Support\ConfigurableInterface;
 
 interface ExceptionMiddlewareInterface extends ConfigurableInterface
 {
-    public function handleException(Exception $exception, Request $request): ?Request;
+    public function handleException(RequestException $requestException): RequestException;
 }

--- a/src/Downloader/Middleware/FakeMiddleware.php
+++ b/src/Downloader/Middleware/FakeMiddleware.php
@@ -16,7 +16,9 @@ namespace RoachPHP\Downloader\Middleware;
 use Exception;
 use PHPUnit\Framework\Assert;
 use RoachPHP\Downloader\DownloaderMiddlewareInterface;
+use RoachPHP\Http\ExceptionContext;
 use RoachPHP\Http\Request;
+use RoachPHP\Http\RequestException;
 use RoachPHP\Http\Response;
 use RoachPHP\Support\Configurable;
 
@@ -45,6 +47,7 @@ final class FakeMiddleware implements DownloaderMiddlewareInterface
     /**
      * @param ?\Closure(Request): Request   $requestHandler
      * @param ?\Closure(Response): Response $responseHandler
+     * @param ?\Closure(RequestException): RequestException $exceptionHandler
      */
     public function __construct(
         private ?\Closure $requestHandler = null,
@@ -75,15 +78,15 @@ final class FakeMiddleware implements DownloaderMiddlewareInterface
         return $response;
     }
 
-    public function handleException(Exception $exception, Request $request): ?Request
+    public function handleException(RequestException $requestException): RequestException
     {
-        $this->exceptionsHandled[] = $exception;
+        $this->exceptionsHandled[] = $requestException->getReason();
 
         if (null !== $this->exceptionHandler) {
-            return ($this->exceptionHandler)($exception, $request);
+            return ($this->exceptionHandler)($requestException);
         }
 
-        return $request;
+        return $requestException;
     }
 
     public function assertRequestHandled(Request $request): void

--- a/src/Events/ExceptionReceived.php
+++ b/src/Events/ExceptionReceived.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoachPHP\Events;
+
+use Exception;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class ExceptionReceived extends Event
+{
+    public const NAME = 'exception.processed';
+
+    public function __construct(public Exception $exception)
+    {
+    }
+}

--- a/src/Events/ExceptionReceiving.php
+++ b/src/Events/ExceptionReceiving.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoachPHP\Events;
+
+use Exception;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class ExceptionReceiving extends Event
+{
+    public const NAME = 'exception.receiving';
+
+    public function __construct(public Exception $exception)
+    {
+    }
+}

--- a/src/Extensions/LoggerExtension.php
+++ b/src/Extensions/LoggerExtension.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace RoachPHP\Extensions;
 
 use Psr\Log\LoggerInterface;
+use RoachPHP\Events\ExceptionReceived;
 use RoachPHP\Events\ItemDropped;
 use RoachPHP\Events\ItemScraped;
 use RoachPHP\Events\RequestDropped;
@@ -39,6 +40,7 @@ final class LoggerExtension implements ExtensionInterface
             RequestDropped::NAME => ['onRequestDropped', 100],
             ItemScraped::NAME => ['onItemScraped', 100],
             ItemDropped::NAME => ['onItemDropped', 100],
+            ExceptionReceived::NAME => ['onExceptionReceived', 100],
         ];
     }
 
@@ -79,6 +81,13 @@ final class LoggerExtension implements ExtensionInterface
         $this->logger->info('Item dropped', [
             'item' => $event->item->all(),
             'reason' => $event->item->getDropReason(),
+        ]);
+    }
+
+    public function onExceptionReceived(ExceptionReceived $event): void
+    {
+        $this->logger->warning('Exception received', [
+            'exception' => $event->exception,
         ]);
     }
 }

--- a/src/Http/FakeGuzzleException.php
+++ b/src/Http/FakeGuzzleException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RoachPHP\Http;
 
 use Exception;

--- a/src/Http/FakeGuzzleException.php
+++ b/src/Http/FakeGuzzleException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace RoachPHP\Http;
+
+use Exception;
+use GuzzleHttp\Exception\GuzzleException;
+
+class FakeGuzzleException extends Exception implements GuzzleException
+{
+}

--- a/src/Http/RequestException.php
+++ b/src/Http/RequestException.php
@@ -17,6 +17,8 @@ use GuzzleHttp\Exception\GuzzleException;
 
 final class RequestException extends \Exception
 {
+    private bool $handled = false;
+
     public function __construct(
         private Request $request,
         private GuzzleException|\Exception $reason,
@@ -32,5 +34,17 @@ final class RequestException extends \Exception
     public function getReason(): GuzzleException|\Exception
     {
         return $this->reason;
+    }
+
+    public function isHandled(): bool
+    {
+        return $this->handled;
+    }
+
+    public function setHandled(): self
+    {
+        $this->handled = true;
+
+        return $this;
     }
 }

--- a/src/Http/RequestException.php
+++ b/src/Http/RequestException.php
@@ -19,7 +19,7 @@ final class RequestException extends \Exception
 {
     public function __construct(
         private Request $request,
-        private GuzzleException $reason,
+        private GuzzleException|\Exception $reason,
     ) {
         parent::__construct('An exception occurred while sending a request', previous: $reason);
     }
@@ -29,7 +29,7 @@ final class RequestException extends \Exception
         return $this->request;
     }
 
-    public function getReason(): GuzzleException
+    public function getReason(): GuzzleException|\Exception
     {
         return $this->reason;
     }

--- a/tests/Downloader/DownloaderMiddlewareAdapterTest.php
+++ b/tests/Downloader/DownloaderMiddlewareAdapterTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace RoachPHP\Tests\Downloader;
 
+use Exception;
 use PHPUnit\Framework\TestCase;
 use RoachPHP\Downloader\DownloaderMiddlewareInterface;
 use RoachPHP\Downloader\Middleware\DownloaderMiddlewareAdapter;
@@ -43,6 +44,11 @@ final class DownloaderMiddlewareAdapterTest extends TestCase
             public function handleResponse(Response $response): Response
             {
                 return $response;
+            }
+
+            public function handleException(Exception $exception, Request $request): ?Request
+            {
+                return $request;
             }
         };
 

--- a/tests/Downloader/DownloaderMiddlewareAdapterTest.php
+++ b/tests/Downloader/DownloaderMiddlewareAdapterTest.php
@@ -20,6 +20,7 @@ use RoachPHP\Downloader\Middleware\DownloaderMiddlewareAdapter;
 use RoachPHP\Downloader\Middleware\RequestMiddlewareInterface;
 use RoachPHP\Downloader\Middleware\ResponseMiddlewareInterface;
 use RoachPHP\Http\Request;
+use RoachPHP\Http\RequestException;
 use RoachPHP\Http\Response;
 use RoachPHP\Support\Configurable;
 use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
@@ -46,9 +47,9 @@ final class DownloaderMiddlewareAdapterTest extends TestCase
                 return $response;
             }
 
-            public function handleException(Exception $exception, Request $request): ?Request
+            public function handleException(RequestException $requestException): RequestException
             {
-                return $request;
+                return $requestException;
             }
         };
 

--- a/tests/Extensions/LoggerExtensionTest.php
+++ b/tests/Extensions/LoggerExtensionTest.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace RoachPHP\Tests\Extensions;
 
+use Exception;
 use RoachPHP\Core\Run;
+use RoachPHP\Events\ExceptionReceived;
 use RoachPHP\Events\ItemDropped;
 use RoachPHP\Events\ItemScraped;
 use RoachPHP\Events\RequestDropped;
@@ -125,6 +127,20 @@ final class LoggerExtensionTest extends ExtensionTestCase
 
         self::assertTrue(
             $this->logger->messageWasLogged('info', 'Item scraped', ['foo' => 'bar']),
+        );
+    }
+
+    public function testLogWhenExceptionWasReceived(): void
+    {
+        self::assertFalse(
+            $this->logger->messageWasLogged('warning', 'Exception received'),
+        );
+
+        $exception = new Exception();
+        $this->dispatch(new ExceptionReceived($exception), ExceptionReceived::NAME);
+
+        self::assertTrue(
+            $this->logger->messageWasLogged('warning', 'Exception received', ['exception' => $exception]),
         );
     }
 

--- a/tests/Http/RequestExceptionTest.php
+++ b/tests/Http/RequestExceptionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoachPHP\Tests\Http;
+
+use PHPUnit\Framework\TestCase;
+use RoachPHP\Http\ExceptionContext;
+use RoachPHP\Http\RequestException;
+use RoachPHP\Testing\Concerns\InteractsWithRequestsAndResponses;
+
+/**
+ * @group http
+ *
+ * @internal
+ */
+final class RequestExceptionTest extends TestCase
+{
+    use InteractsWithRequestsAndResponses;
+
+    public function testHandled(): void
+    {
+        $exception = new RequestException($this->makeRequest(), new \Exception());
+
+        $this->assertFalse($exception->isHandled());
+
+        $exception = $exception->setHandled();
+        $this->assertTrue($exception->isHandled());
+    }
+}


### PR DESCRIPTION
This PR adds exception handling to the downloader and allows middleware to act upon caught exceptions.

Personally, I need this for handling Javascript (Browsershot) exceptions, so I can retry them. In order to act upon thrown exceptions during the request being sent, exception handling is needed at the downloader level.